### PR TITLE
Set correct name for SI-3(1)

### DIFF
--- a/data/standards/NIST-800-53.yaml
+++ b/data/standards/NIST-800-53.yaml
@@ -939,7 +939,7 @@ SI-3:
   name: Malicious Code Protection
 SI-3 (1):
   family: SI
-  name: Malicious Code Protection | essential Management
+  name: Malicious Code Protection | Central Management
 SI-3 (2):
   family: SI
   name: Malicious Code Protection | Automatic Updates


### PR DESCRIPTION
Control enhancement SI-3(1) is named incorrectly. Update based on NIST
spec from
https://web.nvd.nist.gov/view/800-53/Rev4/control?controlName=SI-3#enhancement-1