### PR TITLE
AWS vs Amazon

### DIFF
--- a/data/markdowns/gitbook/ssp.yaml
+++ b/data/markdowns/gitbook/ssp.yaml
@@ -49,5 +49,5 @@ information_system:
   deployment_model: Public
   leveraged_authorizations:
     - system_name:
-      owner: Amazon
+      owner: Amazon Web Services (AWS)
       date_granted: 2013-13-05


### PR DESCRIPTION
We should use AWS instead, as that's canonical name on procurement and billing docs and such