### PR TITLE
fix certification used in the instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The get command will import all the data from the cg-compliance repository and d
 0. Create Gitbook Documentation
 
   ```bash
-  compliance-masonry docs gitbook LATO # `LATO` or `FedRAMP-low` .. etc.
+  compliance-masonry docs gitbook FedRAMP-moderate # or `FedRAMP-low`
   ```
 
 0. Serve the Gitbook locally


### PR DESCRIPTION
LATO is not one of the certifications included in https://github.com/opencontrol/FedRAMP-Certifications, so the command didn't work as written.

```
$ compliance-masonry docs gitbook LATO
Error: `opencontrols/certifications/LATO.yaml` does not exist
Use one of the following:
`FedRAMP-low`
`FedRAMP-moderate`
```

/cc @jcscottiii @ctro @DavidEBest 