### PR TITLE
Better SI_Policy narratives

### DIFF
--- a/SI_Policy/component.yaml
+++ b/SI_Policy/component.yaml
@@ -120,7 +120,7 @@ satisfies:
   narrative:
   - key: a
     text: |
-      The 18F DevOps and SecOps teams monitors the Cloud.Gov information
+      The 18F DevOps and SecOps teams monitors the cloud.gov information
       system to detect potential attacks and intrusions from internal and external
       sources in accordance with the 18F System Information and Integrity Policy section
       3 - Information System monitoring, the FedRAMP Incident communication procedures
@@ -128,18 +128,18 @@ satisfies:
       Review" for GSA specifc infomation systems.
   - key: b
     text: |
-      18F identifies un-authorized access to the Cloud.Gov information system using automated monitoring
+      18F identifies un-authorized access to the cloud.gov information system using automated monitoring
       tools within its virutal proviate cloud for monitoringing, log management and
       event analysis. 18F monitors for attacks and indicators of potential attacks,
       unauthorized local, network, and remote connections.
   - key: c
     text: |
       The infrastructure
-      that hosts Cloud.Gov provides monitoring and intrusion detcetion of unsual activity
+      that hosts cloud.gov provides monitoring and intrusion detcetion of unsual activity
       at the phyical and network layers. 18F is responsible for monitoring everything
       related to its virtual infrastructure and has deployed monitoring  and intrusion
       dectction tools within its virtual private cloud to log and dectect malicious
-      activities to its information systems including Cloud.Gov.
+      activities to its information systems including cloud.gov.
   - key: d
     text: |
       18F ensures intrusion and monitoring tools are protected  from unauthorized access
@@ -154,8 +154,9 @@ satisfies:
       security communities, and other sources.
   - key: f
     text: |
-      Information system monitoring will be conducted in accordance and compliance with 18F security policies and
-      all applicable laws, Executive Orders, directives, and regulations.
+      Information system monitoring will be conducted in accordance and compliance
+      with 18F security policies and all applicable laws, Executive Orders, directives,
+      and regulations.
   - key: g
     text: |
       18F provides monitoring of all information system components in the event
@@ -170,7 +171,7 @@ satisfies:
   implementation_status: none
   narrative:
   - text: |
-      **DEFAULT_CONTROL** 18F connects and configures individual intrusion detection tools into an information system-wide intrusion detection system.
+      The 18F DevOps and SecOps team uses BOSH to configure and deploy Tripwire.
   standard_key: NIST-800-53
 - control_key: SI-4 (2)
   covered_by:
@@ -178,8 +179,8 @@ satisfies:
   implementation_status: none
   narrative:
   - text: |
-      **DEFAULT_CONTROL** The organization employs automated tools to support near
-      real-time analysis of events.
+      18F uses BOSH to configure and deploy Riemann to support near real-time
+      analysis of events.
   standard_key: NIST-800-53
 - control_key: SI-4 (4)
   covered_by:
@@ -187,9 +188,8 @@ satisfies:
   implementation_status: none
   narrative:
   - text: |
-      **DEFAULT_CONTROL** The information system monitors inbound and outbound
-      communications traffic [Assignment: organization-defined frequency] for
-      unusual or unauthorized activities or conditions.
+      cloud.gov monitors inbound and outbound communications traffic [FedRAMP
+      Assignment: continually] for unusual or unauthorized activities or conditions.
   standard_key: NIST-800-53
 - control_key: SI-4 (5)
   covered_by:
@@ -197,10 +197,9 @@ satisfies:
   implementation_status: none
   narrative:
   - text: |
-      **DEFAULT_CONTROL** The information system alerts [Assignment:
-      organization-defined personnel or roles] when the following indications of
-      compromise or potential compromise occur: [Assignment: organization-defined
-      compromise indicators].
+      cloud.gov alerts [Assignment: organization-defined personnel or roles] when
+      the following indications of compromise or potential compromise occur:
+      [Assignment: organization-defined compromise indicators].
   standard_key: NIST-800-53
 - control_key: SI-4 (14)
   covered_by:
@@ -208,7 +207,7 @@ satisfies:
   implementation_status: none
   narrative:
   - text: |
-      **DEFAULT_CONTROL** 18F employs a wireless intrusion detection system to identify rogue wireless devices and to detect attack attempts and potential compromises/breaches to the information system.
+      This control is not applicable. cloud.gov does not contain any wireless system.
   standard_key: NIST-800-53
 - control_key: SI-4 (16)
   covered_by:
@@ -216,7 +215,7 @@ satisfies:
   implementation_status: none
   narrative:
   - text: |
-      **DEFAULT_CONTROL** 18F correlates information from monitoring tools employed throughout the information system.
+      18F correlates information from Grafana employed throughout cloud.gov.
   standard_key: NIST-800-53
 - control_key: SI-4 (23)
   covered_by:
@@ -225,7 +224,8 @@ satisfies:
   narrative:
   - key: a
     text: |
-      **DEFAULT_CONTROL** 18F implements [Assignment: organization-defined host-based monitoring mechanisms (Grafana)] at [Assignment: organization-defined information system components(cloud.gov)].
+      18F implements Grafana [Assignment: organization-defined host-based monitoring mechanisms] on
+      cloud.gov [Assignment: organization-defined information system components].
   standard_key: NIST-800-53
 - control_key: SI-5
   covered_by:

--- a/SI_Policy/component.yaml
+++ b/SI_Policy/component.yaml
@@ -256,16 +256,20 @@ satisfies:
   narrative:
     - key: a
       text: |
-        **DEFAULT_CONTROL** Verifies the correct operation of [Assignment: organization-defined security functions];
+        Verifies the correct operation of [Assignment: organization-defined security
+        functions];
     - key: b
       text: |
-        **DEFAULT_CONTROL** Performs this verification [Selection (one or more): [Assignment: organization-defined system transitional states]; upon command by user with appropriate privilege; [Assignment: organization-defined frequency]];
+        Performs this verification [FedRAMP Assignment: to include upon system startup
+        and/or restart at least monthly
     - key: c
       text: |
-        **DEFAULT_CONTROL** Notifies [Assignment: organization-defined personnel or roles] of failed security verification tests; and
+        Notifies [FedRAMP Assignment: to include system administrators and security
+        personnel] of failed security verification tests; and
     - key: d
       text: |
-        **DEFAULT_CONTROL** [Selection (one or more): shuts the information system down; restarts the information system; [Assignment: organization-defined alternative action(s)]] when anomalies are discovered.standard_key: NIST-800-53
+        Shuts the information system down; [FedRAMP Assignment: to include notification
+        of system administrators and security personnel] when anomalies are discovered.
   standard_key: NIST-800-53
 - control_key: SI-7
   covered_by:

--- a/SI_Policy/component.yaml
+++ b/SI_Policy/component.yaml
@@ -360,7 +360,7 @@ satisfies:
   implementation_status: none
   narrative:
   - text: |
-      **DEFAULT_CONTROL** The information system implements [Assignment: organization-defined security safeguards] to protect its memory from unauthorized code execution.
+      The information system implements [Assignment: organization-defined security safeguards] to protect its memory from unauthorized code execution.
   standard_key: NIST-800-53
 system: 18F
 verifications:

--- a/SI_Policy/component.yaml
+++ b/SI_Policy/component.yaml
@@ -277,7 +277,8 @@ satisfies:
   implementation_status: none
   narrative:
   - text: |
-      **DEFAULT_CONTROL** The organization employs integrity verification tools to detect unauthorized changes to [Assignment: organization-defined software, firmware, and information].
+      18F employs Tripwire to detect unauthorized changes to [Assignment:
+      organization-defined software, firmware, and information].
   standard_key: NIST-800-53
 - control_key: SI-7 (1)
   covered_by:
@@ -285,7 +286,7 @@ satisfies:
   implementation_status: none
   narrative:
   - text: |
-      **DEFAULT_CONTROL** The information system performs an integrity check of [Assignment: organization-defined software, firmware, and information] [Selection (one or more): at startup; at [Assignment: organization-defined transitional states or security-relevant events]; [Assignment: organization-defined frequency]].
+      cloud.gov performs an integrity check using Tripwire at startup; and every hour.
   standard_key: NIST-800-53
 - control_key: SI-7 (7)
   covered_by:
@@ -293,7 +294,9 @@ satisfies:
   implementation_status: none
   narrative:
   - text: |
-      **DEFAULT_CONTROL** The organization incorporates the detection of unauthorized [Assignment: organization-defined security-relevant changes to the information system] into the organizational incident response capability.
+      18F incorporates the detection of unauthorized [Assignment: organization-
+      defined security-relevant changes to the information system] into the
+      organizational incident response capability.
   standard_key: NIST-800-53
 - control_key: SI-8
   covered_by:

--- a/SI_Policy/component.yaml
+++ b/SI_Policy/component.yaml
@@ -234,16 +234,20 @@ satisfies:
   narrative:
     - key: a
       text: |
-        **DEFAULT_CONTROL** Receives information system security alerts, advisories, and directives from [Assignment: organization-defined external organizations] on an ongoing basis;
+        18F receives information system security alerts, advisories, and directives from [Assignment: organization-defined external organizations] on an ongoing basis;
     - key: b
       text: |
-        **DEFAULT_CONTROL** Generates internal security alerts, advisories, and directives as deemed necessary;
+        18F generates internal security alerts, advisories, and directives as deemed necessary;
     - key: c
       text: |
-        **DEFAULT_CONTROL** Disseminates security alerts, advisories, and directives to: [Selection (one or more): [Assignment: organization-defined personnel or roles]; [Assignment: organization-defined elements within the organization]; [Assignment: organization-defined external organizations]]; and
+        18F disseminates security alerts, advisories, and directives to: [Selection
+        (one or more): [Assignment: organization-defined personnel or roles];
+        [Assignment: organization-defined elements within the organization];
+        [Assignment: organization-defined external organizations]]; and
     - key: d
       text: |
-        **DEFAULT_CONTROL** Implements security directives in accordance with established time frames, or notifies the issuing organization of the degree of noncompliance.
+        18F implements security directives in accordance with established time
+        frames, or notifies the issuing organization of the degree of noncompliance.
   standard_key: NIST-800-53
 - control_key: SI-6
   covered_by:

--- a/SI_Policy/component.yaml
+++ b/SI_Policy/component.yaml
@@ -64,17 +64,17 @@ satisfies:
   narrative:
     - key: a
       text: |
-        **DEFAULT_CONTROL** Employs malicious code protection mechanisms at information
-        system entry and exit points to detect and eradicate malicious code;
+        cloud.gov employs ClamAV at information system entry and exit points to
+        detect and eradicate malicious code;
     - key: b
       text: |
-        **DEFAULT_CONTROL** Updates malicious code protection mechanisms whenever
-        new releases are available in accordance with organizational configuration management policy and procedures;
+        18F updates ClamAV whenever new releases are available in accordance
+        with organizational configuration management policy and procedures;
     - key: c
       text: |
-        **DEFAULT_CONTROL** Configures malicious code protection mechanisms to:
+        The 18F DevOps and SecOps teams configures ClamAV to:
 
-          1. Perform periodic scans of the information system [Assignment: organization-
+          1. Perform on-access scans of cloud.gov [Assignment: organization-
           defined frequency] and real-time scans of files from external sources at
           [Selection (one or more); endpoint; network entry/exit points] as the files
           are downloaded, opened, or executed in accordance with organizational
@@ -85,7 +85,7 @@ satisfies:
           in response to malicious code detection; and
     - key: d
       text: |
-        **DEFAULT_CONTROL** Addresses the receipt of false positives during malicious
+        cloud.gov addresses the receipt of false positives during malicious
         code detection and eradication and the resulting potential impact on the
         availability of the information system.
   standard_key: NIST-800-53
@@ -95,8 +95,7 @@ satisfies:
   implementation_status: none
   narrative:
   - text: |
-      **DEFAULT_CONTROL** 18F centrally manages malicious code protection
-      mechanisms.
+      18F centrally manages malicious code protection mechanisms.
   standard_key: NIST-800-53
 - control_key: SI-3 (2)
   covered_by:
@@ -104,8 +103,7 @@ satisfies:
   implementation_status: none
   narrative:
   - text: |
-      **DEFAULT_CONTROL** cloud.gov automatically updates malicious code
-      protection mechanisms.
+      cloud.gov automatically updates ClamAV malicious code protection mechanisms.
   standard_key: NIST-800-53
 - control_key: SI-3 (7)
   covered_by:
@@ -113,8 +111,7 @@ satisfies:
   implementation_status: none
   narrative:
   - text: |
-      **DEFAULT_CONTROL** cloud.gov implements nonsignature-based
-      malicious code detection mechanisms.
+     cloud.gov implements nonsignature-based malicious code detection mechanisms.
   standard_key: NIST-800-53
 - control_key: SI-4
   covered_by:

--- a/SI_Policy/component.yaml
+++ b/SI_Policy/component.yaml
@@ -305,10 +305,10 @@ satisfies:
   narrative:
   - key: a
     text: |
-      **DEFAULT_CONTROL** Employs spam protection mechanisms at information system entry and exit points to detect and take action on unsolicited messages; and
+      Employs spam protection mechanisms at information system entry and exit points to detect and take action on unsolicited messages; and
   - key: b
     text: |
-      **DEFAULT_CONTROL** Updates spam protection mechanisms when new releases are available in accordance with organizational configuration management policy and procedures.
+      Updates spam protection mechanisms when new releases are available in accordance with organizational configuration management policy and procedures.
   standard_key: NIST-800-53
 - control_key: SI-8 (1)
   covered_by:
@@ -316,7 +316,7 @@ satisfies:
   implementation_status: none
   narrative:
   - text: |
-      **DEFAULT_CONTROL** The organization centrally manages spam protection mechanisms.
+      The organization centrally manages spam protection mechanisms.
   standard_key: NIST-800-53
 - control_key: SI-8 (2)
   covered_by:
@@ -324,7 +324,7 @@ satisfies:
   implementation_status: none
   narrative:
   - text: |
-      **DEFAULT_CONTROL** The information system automatically updates spam protection mechanisms.
+      The information system automatically updates spam protection mechanisms.
   standard_key: NIST-800-53
 - control_key: SI-10
   covered_by:

--- a/SI_Policy/component.yaml
+++ b/SI_Policy/component.yaml
@@ -352,7 +352,7 @@ satisfies:
   implementation_status: none
   narrative:
   - text: |
-      **DEFAULT_CONTROL** The organization handles and retains information within the information system and information output from the system in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and operational requirements.
+      The organization handles and retains information within the information system and information output from the system in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and operational requirements.
   standard_key: NIST-800-53
 - control_key: SI-16
   covered_by:

--- a/SI_Policy/component.yaml
+++ b/SI_Policy/component.yaml
@@ -341,10 +341,10 @@ satisfies:
   narrative:
   - key: a
     text: |
-      **DEFAULT_CONTROL** Generates error messages that provide information necessary for corrective actions without revealing information that could be exploited by adversaries; and
+      Generates error messages that provide information necessary for corrective actions without revealing information that could be exploited by adversaries; and
   - key: b
     text: |
-      **DEFAULT_CONTROL** Reveals error messages only to [Assignment: organization-defined personnel or roles].
+      Reveals error messages only to [Assignment: organization-defined personnel or roles].
   standard_key: NIST-800-53
 - control_key: SI-12
   covered_by:

--- a/SI_Policy/component.yaml
+++ b/SI_Policy/component.yaml
@@ -17,21 +17,20 @@ satisfies:
   narrative:
   - key: a
     text: |
-      18F identifies all system flaws related to Cloud.gov, reports
+      18F identifies all system flaws related to cloud.gov, reports
       system flaws to information system owners, Authorizing officials, DevOps and
       SecOp  and corrects information system flaws that affect cloud.gov
 
-      Cloud Foundry
-      manages software vulnerability using releases and BOSH stemcells. New Cloud
-      Foundry releases are created with updates to address code issues, while new
+      Cloud Foundry manages software vulnerability using releases and BOSH stemcells.
+      New Cloud Foundry releases are created with updates to address code issues, while new
       stemcells are created with patches for the latest security fixes to address
       any underlying operating system issues. New Cloud Foundry releases are located
       at https://github.com/cloudfoundry/cf-release.
 
-      18F implements the release
-      of Cloud Foundry he what (or the software developer/vendor in the case of software
-      developed and maintained by a vendor/contractor) promptly installs newly released
-      security relevant patches and tests patches, for effectiveness and potential
+      18F implements the release of Cloud Foundry he what (or the software
+      developer/vendor in the case of software developed and maintained by a
+      vendor/contractor) promptly installs newly released security relevant
+      patches and tests patches, for effectiveness and potential
       side effects on information systems before installation.
   standard_key: NIST-800-53
 - control_key: SI-2 (2)
@@ -40,9 +39,9 @@ satisfies:
   implementation_status: none
   narrative:
   - text: |
-      **DEFAULT_CONTROL** The 18F DevOps and SecOps teams employs automated
-      mechanisms [Assignment: organization-defined frequency] to determine the
-      state of information system components with regard to flaw remediation.
+      The 18F DevOps and SecOps teams employs automated mechanisms [Assignment:
+      organization-defined frequency] to determine the state of information system
+      components with regard to flaw remediation.
   standard_key: NIST-800-53
 - control_key: SI-2 (3)
   covered_by:
@@ -51,12 +50,12 @@ satisfies:
   narrative:
   - key: a
     text: |
-      **DEFAULT_CONTROL** The 18F DevOps and SecOps teams measure the time between
-      flaw identification and flaw remediation; and
+      The 18F DevOps and SecOps teams measure the time between flaw identification
+      and flaw remediation; and
   - key: b
     text: |
-      **DEFAULT_CONTROL** The 18F DevOps and SecOps teams establishes [Assignment:
-      organization-defined benchmarks] for taking corrective actions.
+     The 18F DevOps and SecOps teams establishes [Assignment: organization-defined
+     benchmarks] for taking corrective actions.
   standard_key: NIST-800-53
 - control_key: SI-3
   covered_by:

--- a/SI_Policy/component.yaml
+++ b/SI_Policy/component.yaml
@@ -332,7 +332,7 @@ satisfies:
   implementation_status: none
   narrative:
   - text: |
-      **DEFAULT_CONTROL** The information system checks the validity of [Assignment: organization-defined information inputs].
+      The information system checks the validity of [Assignment: organization-defined information inputs].
   standard_key: NIST-800-53
 - control_key: SI-11
   covered_by:


### PR DESCRIPTION
This patch series addresses the following:

- [x] SI_Policy narratives updated with language from `docx` provided by @clovett3.
- [x] `**DEFAULT_CONTROL**` prefix is now removed to avoid confusion.
- [x] Narratives updated in certain places but will still need to verified for accuracy.