### PR TITLE
Fix BDD tests by using requests instead of urllib

### DIFF
--- a/BDD/steps/policies.py
+++ b/BDD/steps/policies.py
@@ -1,18 +1,15 @@
 from behave import given, then
-from urllib import request
-
+import requests
 import datetime
-
 
 @given('the github link - {url}')
 def step_impl(context, url):
     context.url = url
 
-
 @then('the policy has been updated within the last {days} days')
 def step_impl(context, days):
-    res = request.urlopen(context.url)
+    res = requests.get(context.url)
     last_modified = datetime.datetime.strptime(
-        res.getheader(name='Last-Modified'), "%a, %d %b %Y %H:%M:%S %Z")
+        res.headers.get('Last-Modified'), "%a, %d %b %Y %H:%M:%S %Z")
     x_days_ago = datetime.datetime.now() - datetime.timedelta(days=int(days))
     assert last_modified > x_days_ago


### PR DESCRIPTION
master branch was giving me:

```
$ behave
Exception ImportError: cannot import name request
Traceback (most recent call last):
  File "/Users/pburkholder/Library/Python/2.7/bin/behave", line 11, in <module>
    sys.exit(main())
  File "/Users/pburkholder/Library/Python/2.7/lib/python/site-packages/behave/__main__.py", line 109, in main
    failed = runner.run()
  File "/Users/pburkholder/Library/Python/2.7/lib/python/site-packages/behave/runner.py", line 672, in run
    return self.run_with_paths()
  File "/Users/pburkholder/Library/Python/2.7/lib/python/site-packages/behave/runner.py", line 678, in run_with_paths
    self.load_step_definitions()
  File "/Users/pburkholder/Library/Python/2.7/lib/python/site-packages/behave/runner.py", line 658, in load_step_definitions
    exec_file(os.path.join(path, name), step_module_globals)
  File "/Users/pburkholder/Library/Python/2.7/lib/python/site-packages/behave/runner.py", line 304, in exec_file
    exec(code, globals, locals)
  File "steps/policies.py", line 2, in <module>
    from urllib import request
ImportError: cannot import name request
```

and the requirements.txt already has `requests` but not `urllib`.   This PR 'just works' out of the box now.