### PR TITLE
Use PyYAML safe_dump to avoid !!python tags

### DIFF
--- a/BDD/tagger.py
+++ b/BDD/tagger.py
@@ -57,5 +57,5 @@ def tag_component(context, tag):
             data['verifications'].append(test_data)
         with open(component_file, 'w') as yaml_file:
             yaml_file.write(
-                yaml.dump(data, default_flow_style=False, indent=2)
+                yaml.safe_dump(data, default_flow_style=False, indent=2)
             )


### PR DESCRIPTION
behave was generating output like this:

```
$ tail ../AC_Policy/component.yaml
  path: https://github.com/18F/compliance-docs/blob/master/AC-Policy.md
  type: URL
- description: !!python/unicode "GIVEN the github link - <policy> THEN the policy\
    \ has been updated within the last 180 days \n"
  key: !!python/unicode 'Policy_Update_Test'
  last_run: 2016-06-15 17:32:58.791910
  name: !!python/unicode '18F Policies Update'
  path: BDD/policies.feature
  test_passed: true
  type: TEST
```

Since we're not going to represent python objects, just strings, its okay to use
safe_dump in this case.