### PR TITLE
Copyediting SI spelling/grammar

### DIFF
--- a/SI_Policy/component.yaml
+++ b/SI_Policy/component.yaml
@@ -19,7 +19,7 @@ satisfies:
     text: |
       18F identifies all system flaws related to cloud.gov, reports
       system flaws to information system owners, Authorizing officials, DevOps and
-      SecOp  and corrects information system flaws that affect cloud.gov
+      SecOps, and corrects information system flaws that affect cloud.gov.
 
       Cloud Foundry manages software vulnerability using releases and BOSH stemcells.
       New Cloud Foundry releases are created with updates to address code issues, while new
@@ -54,7 +54,7 @@ satisfies:
       and flaw remediation; and
   - key: b
     text: |
-     The 18F DevOps and SecOps teams establishes [Assignment: organization-defined
+     The 18F DevOps and SecOps teams establish [Assignment: organization-defined
      benchmarks] for taking corrective actions.
   standard_key: NIST-800-53
 - control_key: SI-3
@@ -72,7 +72,7 @@ satisfies:
         with organizational configuration management policy and procedures;
     - key: c
       text: |
-        The 18F DevOps and SecOps teams configures ClamAV to:
+        The 18F DevOps and SecOps teams configure ClamAV to:
 
           1. Perform on-access scans of cloud.gov [Assignment: organization-
           defined frequency] and real-time scans of files from external sources at
@@ -120,30 +120,30 @@ satisfies:
   narrative:
   - key: a
     text: |
-      The 18F DevOps and SecOps teams monitors the cloud.gov information
+      The 18F DevOps and SecOps teams monitor the cloud.gov information
       system to detect potential attacks and intrusions from internal and external
       sources in accordance with the 18F System Information and Integrity Policy section
-      3 - Information System monitoring, the FedRAMP Incident communication procedures
+      3 - Information System monitoring, the FedRAMP Incident communication procedures,
       and GSA CIO-IT Security-08-39 section "System Monitoring / Audit Record
-      Review" for GSA specifc infomation systems.
+      Review" for GSA specific information systems.
   - key: b
     text: |
       18F identifies un-authorized access to the cloud.gov information system using automated monitoring
-      tools within its virutal proviate cloud for monitoringing, log management and
+      tools within its virtual private cloud for monitoring, log management and
       event analysis. 18F monitors for attacks and indicators of potential attacks,
       unauthorized local, network, and remote connections.
   - key: c
     text: |
       The infrastructure
-      that hosts cloud.gov provides monitoring and intrusion detcetion of unsual activity
-      at the phyical and network layers. 18F is responsible for monitoring everything
-      related to its virtual infrastructure and has deployed monitoring  and intrusion
-      dectction tools within its virtual private cloud to log and dectect malicious
+      that hosts cloud.gov provides monitoring and intrusion detcetion of unusual activity
+      at the physical and network layers. 18F is responsible for monitoring everything
+      related to its virtual infrastructure and has deployed monitoring and intrusion
+      detection tools within its virtual private cloud to log and detect malicious
       activities to its information systems including cloud.gov.
   - key: d
     text: |
-      18F ensures intrusion and monitoring tools are protected  from unauthorized access
-      by only granting access to certian members from the DevOps and SecOps team.
+      18F ensures intrusion and monitoring tools are protected from unauthorized access
+      by only granting access to certain members from the DevOps and SecOps teams.
       All monitoring and intrusion information data is protected by limiting accounts
       to authorized privileged users only and is maintained in secured repositories
       for review by those members.
@@ -159,10 +159,10 @@ satisfies:
       and regulations.
   - key: g
     text: |
-      18F provides monitoring of all information system components in the event
+      18F provides monitoring of all information system components. In the event
       of an event or incident, information will be provided as it is available.  Scheduled
       reports will be provided for events such as after-hours administrative logins,
-      users being added to privileged groups, persistent malware detections, etc.
+      users being added to privileged groups, persistent malware detections, etc.,
       to designated members of the DevOps teams and SecOps teams as needed.
   standard_key: NIST-800-53
 - control_key: SI-4 (1)
@@ -171,7 +171,7 @@ satisfies:
   implementation_status: none
   narrative:
   - text: |
-      The 18F DevOps and SecOps team uses BOSH to configure and deploy Tripwire.
+      The 18F DevOps and SecOps teams use BOSH to configure and deploy Tripwire.
   standard_key: NIST-800-53
 - control_key: SI-4 (2)
   covered_by:
@@ -261,7 +261,7 @@ satisfies:
     - key: b
       text: |
         Performs this verification [FedRAMP Assignment: to include upon system startup
-        and/or restart at least monthly
+        and/or restart at least monthly;
     - key: c
       text: |
         Notifies [FedRAMP Assignment: to include system administrators and security
@@ -286,7 +286,7 @@ satisfies:
   implementation_status: none
   narrative:
   - text: |
-      cloud.gov performs an integrity check using Tripwire at startup; and every hour.
+      cloud.gov performs an integrity check using Tripwire at startup and every hour.
   standard_key: NIST-800-53
 - control_key: SI-7 (7)
   covered_by:


### PR DESCRIPTION
* This document was grammatically inconsistent about whether there are two "18F DevOps and SecOps teams" or a single "18F DevOps and SecOps team", so I made this consistent as plural.
* Fixed some spelling.