### PR TITLE
Upgrade schema for CICloudGov SI-2

### DIFF
--- a/CICloudGov/component.yaml
+++ b/CICloudGov/component.yaml
@@ -5,14 +5,18 @@ satisfies:
   covered_by:
   - verification_key: CONCOURSE_PIPELINE
   implementation_status: none
-  narrative: "#### b  \nTests software and firmware updates related to flaw remediation\
-    \ for effectiveness and potential side effects before installation.\n  \n####\
-    \ c  \nInstalls security-relevant software and firmware updates within 30 daysrelease\
-    \ of updates of the release of the updates.\n  \n#### d  \n18F incorporates flaw\
-    \ remediation into the its configuration management process. New versions of cloud.gov\
-    \ can easily recreated and deployed in the event of any system flaws.\n  \n"
+  narrative:
+    - key: b
+      text: |
+        Tests software and firmware updates related to flaw remediation for effectiveness and potential side effects before installation.
+    - key: c
+      text: |
+        Installs security-relevant software and firmware updates within 30 days release of updates of the release of the updates.
+    - key: d
+      text: |
+        18F incorporates flaw remediation into the its configuration management process. New versions of cloud.gov can easily recreated and deployed in the event of any system flaws.
   standard_key: NIST-800-53
-schema_version: 2.0
+schema_version: 3.0.0
 verifications:
 - key: CONCOURSE_PIPELINE
   name: CI cloud.gov Concourse Pipeline


### PR DESCRIPTION
This patch series updates the Schema from `2.0` to `3.0`.