### PR TITLE
Copyediting SC for clarity and consistency

### DIFF
--- a/SC_Policy/component.yaml
+++ b/SC_Policy/component.yaml
@@ -11,23 +11,23 @@ satisfies:
     text: |
       System and Communications Protection Policy is included in CIO P 2100.1 - GSA IT Security Policy, Chapter 5. Policy on Technical Controls.  It states, "All network devices that are either owned, managed, maintain a connection to a GSA facility, and/or handle GSA data shall be strategically positioned behind a GSA firewall to provide analysis/correlation, management structure, and minimize threats presented by external attacks.
 
-      18F Policy the 18F program includes a library of security policies that address federal and non-federal requirements. These policies guide and govern the actions of 18F employees and contractors in conducting any United States business.
+      The 18F program includes a library of security policies that address federal and non-federal requirements. These policies guide and govern the actions of 18F employees and contractors in conducting any United States business.
 
-      The 18F security assessment, communications and authorization policy is listed within its GitHub repository that is accessible to all 18F staff.
+      The 18F security assessment, communications, and authorization policy is listed within its GitHub repository that is accessible to all 18F staff.
 
       18F helps develop, document, and disseminate policy information to 18F staff members.
 
-      18F policy contains protection policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance.
+      This 18F policy contains a protection policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance.
 
-      18F "Before You Ship" guide aids to facilitate the implementation of the system and communications protection policy and associated system and communications protection controls.
+      18F's "Before You Ship" guide facilitates the implementation of the system and communications protection policy and associated system and communications protection controls.
     link: https://github.com/18F/before-you-ship/
   - key: b
     text: |
-      Reviews and updates the current System and communications protection policy every three years.
+      Reviews and updates the current System and Communications Protection Policy every three years.
 
-      18F Policy the 18F program includes a library of security policies that address federal and non-federal requirements. These policies guide and govern the actions of 18F employees and contractors in conducting any United States business.
+      The 18F program includes a library of security policies that address federal and non-federal requirements. These policies guide and govern the actions of 18F employees and contractors in conducting any United States business.
 
-      The 18F security assessment, communications and authorization policy are listed within its private Github repository that is accessible to all 18F staff.
+      The 18F security assessment, communications, and authorization policy is listed within its GitHub repository that is accessible to all 18F staff.
   standard_key: NIST-800-53
 - control_key: SC-2
   covered_by: []
@@ -42,7 +42,7 @@ satisfies:
   implementation_status: complete
   narrative:
   - text: |
-      cloud.gov system architecture prevents unauthorized and unintended information transfer via shared system resources. cloud.gov uses Cloudfoundry components to protect users and shared resources from security threats by minimizing network surface area, applying security controls, isolating customer applications and data in containers, and encrypting connections.
+      cloud.gov system architecture prevents unauthorized and unintended information transfer via shared system resources. cloud.gov uses Cloud Foundry components to protect users and shared resources from security threats by minimizing network surface area, applying security controls, isolating customer applications and data in containers, and encrypting connections.
   standard_key: NIST-800-53
 - control_key: SC-5
   covered_by: []
@@ -51,14 +51,15 @@ satisfies:
   - text: |
       Refer to the 18F policy statement for the types of denial of service (DoS) to protect our systems against. Policy https://github.com/18f/compliance-docs/blob/master/SC-Policy.md
 
-      cloud.gov limits the effects of Volume Based and Protocol DoS type attacks by utilizing the following groups of technical measure:
+      cloud.gov limits the effects of Volume Based and Protocol DoS type attacks by utilizing the following groups of technical measures:
 
-      18F administrative staff maintains hardened Amazon Managed Images (AMI) and Cloud Foundry custom buildpacks with the lates patches and updates.
-      A buildpacks provides framework and runtime support for an applications that are deployed on cloud.gov.  The AMI and custome buildpacks are maintained and secured within 18F's software repository, GitHub.
+      18F administrative staff maintains hardened Amazon Managed Images (AMI) and Cloud Foundry custom buildpacks with the latest patches and updates.
+      
+      Buildpacks provide framework and runtime support for applications that are deployed on cloud.gov.  The AMI and custom buildpacks are maintained and secured within 18F's software repository, GitHub.
 
-      cloud.gov also uses AWS's IaaS services with well formed Vitual Private Cloud (VPC) firewall rules to reduce the attack surface, while service resiliencey is maintained by utilizing AWS Avaliability zones, Elastic Load balancing and Autoscaling services.
+      cloud.gov also uses AWS's IaaS services with well-formed Virtual Private Cloud (VPC) firewall rules to reduce the attack surface, while service resiliency is maintained by utilizing AWS Availability Zones, Elastic Load Balancing, and Auto Scaling services.
 
-      Cloud Foundry's security components limits the effects of an attack at the Application Layer. It limits DoS attacks on this layer through resource starvation and reduction of the attack surface even further with well formed application security groups which control the traffic flowing from hosted applications.
+      Cloud Foundry's security components limit the effects of an attack at the Application Layer. It limits DoS attacks on this layer through resource starvation and reduction of the attack surface even further with well-formed application security groups which control the traffic flowing from hosted applications.
 
       These tools combined with SOC staffing are responsible for maintaining system security.
   parameters:
@@ -75,14 +76,14 @@ satisfies:
   narrative:
   - text: |
       cloud.gov protects the availability of resources by allocating
-      volatile and non-volatile storage, bandwidth, availability by using automated
-      AWS features such as Elasctic load balancing and auto scaling technology at the
-      infrastructure layer and CF's application lifecycle manage components,
+      volatile and non-volatile storage, bandwidth, and availability by using automated
+      AWS features such as Elastic Load Balancing and Auto Scaling technology at the
+      infrastructure layer and Cloud Foundry's application lifecycle manager components,
       Cloud Controller and Droplet Execution Agent (DEA), at the application layers.
 
-      18F safeguards are in place if resource are reaching their limits with multiple sets of
-      resource monitoring tools:  CF's build in health monitoring system, New Relic,
-      CloudWatch, ELK which combined provide with real-time alerts and visibility into critical
+      18F safeguards are in place if resources are reaching their limits with multiple sets of
+      resource monitoring tools:  Cloud Foundry's built-in health monitoring system, New Relic,
+      CloudWatch, and ELK, which combined provide real-time alerts and visibility into critical
       systems and applications.
   parameters:
   - key: a
@@ -104,11 +105,11 @@ satisfies:
       18F monitors and controls communications at the external boundary of the system and at key internal boundaries within the system.
   - key: b
     text: |
-      18F implements subnetworks for publicly accessible system components that are logically separated from internal organizational networks by using well formed Virtual Private Cloud. VPC is a virtual network dedicated to your AWS account which is logically isolated from other virtual networks in the AWS cloud.
+      18F implements subnetworks for publicly accessible system components that are logically separated from internal organizational networks by using a well-formed Virtual Private Cloud. VPC is a virtual network dedicated to your AWS account which is logically isolated from other virtual networks in the AWS cloud.
       cloud.gov VPC has selected its IP address range, created subnets, and configured route tables, network gateways, and security settings logically separated from any other internal organization networks.
   - key: c
     text: |
-      18F staff Connects to external networks or information systems only through managed interfaces consisting of boundary protection devices arranged in accordance with organizational security architecture.
+      18F staff connects to external networks or information systems only through managed interfaces consisting of boundary protection devices arranged in accordance with organizational security architecture.
   parameters:
   - key: b
     text: |
@@ -119,9 +120,9 @@ satisfies:
   implementation_status: complete
   narrative:
   - text: |
-      18F limits the number external network connections to the information system through the use of AWS network security groups which restricts types of network connections. AWS API authenticated service keys and managed ssh keys restrict PU access to the systems.
+      18F limits the number of external network connections to the information system through the use of AWS network security groups which restrict types of network connections. AWS API authenticated service keys and managed SSH keys restrict PU access to the systems.
 
-      cloud.gov Cloud Foundry components run on AWS AMI that exist within AWS VPCs. In this configuration, the only access points visible on a public network are a load balancer that maps to one or more Cloud Foundry routers.
+      cloud.gov Cloud Foundry components run on AWS AMI that exist within AWS VPCs. In this configuration, the only access points visible on a public network are load balancers that map to one or more Cloud Foundry routers.
   standard_key: NIST-800-53
 - control_key: SC-7 (4)
   covered_by: []
@@ -152,21 +153,21 @@ satisfies:
   implementation_status: none
   narrative:
   - text: |
-      cloud.gov's  managed interfaces at the AWS security control group defintions denies network traffic by default and allows network communications traffic by exception.
+      cloud.gov's managed interfaces at the AWS security control group definitions deny network traffic by default and allow network communications traffic by exception.
   standard_key: NIST-800-53
 - control_key: SC-7 (7)
   covered_by: []
   implementation_status: none
   narrative:
   - text: |
-      VPNs and split tunneling are not an applicable use when accessing this system. 18F adminitrative staff gain access to this system have access through AWS multi-factor authentication to perform adminitrative functions and duties.
+      VPNs and split tunneling are not an applicable use when accessing this system. 18F adminitrative staff gain access to this system through AWS multi-factor authentication to perform administrative functions and duties.
   standard_key: NIST-800-53
 - control_key: SC-7 (8)
   covered_by: []
   implementation_status: none
   narrative:
   - text: |
-      cloud.gov doesn't require authenticated proxy servers at managed interfaces. 18F adminitrative staff gain access to this system have access through AWS IAM multi-factor authentication process to perform adminitrative functions and duties at the IaaS layer to administer to any managed interfaces.
+      cloud.gov doesn't require authenticated proxy servers at managed interfaces. 18F administrative staff gain access to this system through the AWS IAM multi-factor authentication process to perform adminitrative functions and duties at the IaaS layer to administer any managed interfaces.
   parameters:
   - key: a
     text: |
@@ -183,7 +184,7 @@ satisfies:
     text: |
       Host-based boundary protection for application services hosted on cloud.gov are provided by CF components.
 
-      Cloud Foundry Application Security Groups (ASGs) control the traffic flowing out of applications. Each cf application uses a dedicated Linux container, and each container includes a dedicated virtual network interface. Application security groups are a collection of ‘allow’ rules that can be made with global or application specific assignments enabling access to be set on individual application requirements. These requirements are added through whitelisting and whitelisting is layered on top of a series of container-centric lock-downs, allowing limited access to other applications and services.
+      Cloud Foundry Application Security Groups (ASGs) control the traffic flowing out of applications. Each CF application uses a dedicated Linux container, and each container includes a dedicated virtual network interface. Application security groups are a collection of ‘allow’ rules that can be made with global or application specific assignments enabling access to be set on individual application requirements. These requirements are added through whitelisting, and whitelisting is layered on top of a series of container-centric lock-downs, allowing limited access to other applications and services.
   parameters:
   - key: a
     text: |
@@ -198,7 +199,7 @@ satisfies:
   narrative:
   - key: b
     text: |
-      18F practices defense in depth in layer. Sensistive security tools are logically isolated by well defined VPC boundries between intera system boundaries.  Additionally 3rd party approved tools are utilized which are accessed via authenticated API keys over encrypted connections such as HTTPS.
+      18F practices defense in depth in layers. Sensistive security tools are logically isolated by well defined VPC boundries between internal system boundaries.  Additionally third-party approved tools are used which are accessed via authenticated API keys over encrypted connections such as HTTPS.
   parameters:
   - key: a
     text: |
@@ -212,7 +213,7 @@ satisfies:
   narrative:
   - key: b
     text: |
-      18F doesn't operate any control interfaces outside of what's provided by AWS CSP. in the event of an operational failure of a boundary protection device AWS CSP teams should respond to this event and notify 18F DevOps team.
+      18F doesn't operate any control interfaces outside of what's provided by AWS CSP. In the event of an operational failure of a boundary protection device, AWS CSP teams should respond to this event and notify the 18F DevOps team.
   standard_key: NIST-800-53
 - control_key: SC-8
   covered_by: []
@@ -254,21 +255,21 @@ satisfies:
   implementation_status: complete
   narrative:
   - text: |
-      Authorized federal staff rotate, encrypt, and backup keys monthly. Privileged users accesses the keys only with two-factor authentication and a decryption passphrase. In the rare case that both the keys and the decryption passphrase for the backup are lost or compromised, new keys can be rotated in by authorized staff, while maintaining availability of information.
+      Authorized federal staff rotate, encrypt, and backup keys monthly. Privileged users access the keys only with two-factor authentication and a decryption passphrase. In the rare case that both the keys and the decryption passphrase for the backup are lost or compromised, new keys can be rotated in by authorized staff, while maintaining availability of information.
   standard_key: NIST-800-53
 - control_key: SC-12 (2)
   covered_by: []
   implementation_status: partial
   narrative:
   - text: |
-      cloud.gov controls, and distributes symmetric cryptographic keys using [NIST FIPS-compliant] key management technology and processes.
+      cloud.gov controls and distributes symmetric cryptographic keys using [NIST FIPS-compliant] key management technology and processes.
   standard_key: NIST-800-53
 - control_key: SC-12 (3)
   covered_by: []
   implementation_status: complete
   narrative:
   - text: |
-      cloud.gov doesn't produce, controls, and distributes asymmetric cryptographic keys using.
+      cloud.gov doesn't produce, control, or distribute asymmetric cryptographic keys.
   parameters:
   - key: SC-12-3
     text: N/A
@@ -290,7 +291,7 @@ satisfies:
   narrative:
   - key: a
     text: |
-      cloud.gov doesn't allow remote activation of collaborative computing devices thus not applicable.
+      cloud.gov doesn't allow remote activation of collaborative computing devices, thus not applicable.
   - key: b
     text: |
       Explicit indication of use to users physically present at the devices is not applicable to cloud.gov.
@@ -311,13 +312,13 @@ satisfies:
   narrative:
   - key: a
     text: |
-      This is not an applicable control for cloud.gov. It doesn't depend on any mobile code such as flash, java, activex, etc.
+      This is not an applicable control for cloud.gov. It doesn't depend on any mobile code such as Flash, Java, ActiveX, etc.
   - key: b
     text: |
-      This is not an applicable control for cloud.gov. It doesn't depend on any mobile code such as flash, java, activex, etc.
+      This is not an applicable control for cloud.gov. It doesn't depend on any mobile code such as Flash, Java, ActiveX, etc.
   - key: c
     text: |
-      This is not an applicable control for cloud.gov. It doesn't depend on any mobile code such as flash, java, activex, etc.
+      This is not an applicable control for cloud.gov. It doesn't depend on any mobile code such as Flash, Java, ActiveX, etc.
   standard_key: NIST-800-53
 - control_key: SC-19
   covered_by: []
@@ -325,10 +326,10 @@ satisfies:
   narrative:
   - key: a
     text: |
-      This is not an applicable control for cloud.gov. It doesn't depend on any VoIP techologies.
+      This is not an applicable control for cloud.gov. It doesn't depend on any VoIP technologies.
   - key: b
     text: |
-      This is not an applicable control for cloud.gov. It doesn't depend on any VoIP techologies.
+      This is not an applicable control for cloud.gov. It doesn't depend on any VoIP technologies.
   standard_key: NIST-800-53
 - control_key: SC-20
   covered_by: []
@@ -336,10 +337,10 @@ satisfies:
   narrative:
   - key: a
     text: |
-      cloud.gov cloud.gov inherits from AWS CSP Route 53 the ability to use DNS with HTTP Strict Transport Security (HSTS) to achieve data origin authentication and integrity verification artifacts along with the authoritative name resolution data the system returns in response to external name/address resolution queries.
+      cloud.gov inherits from AWS CSP Route 53 the ability to use DNS with HTTP Strict Transport Security (HSTS) to achieve data origin authentication and integrity verification artifacts, along with the authoritative name resolution data the system returns in response to external name/address resolution queries.
   - key: b
     text: |
-      By allowing endpints to use Publie Key Infrastructure (PKI) certificates containing unique domain identifiers that map with top-level registered domain, cloud.gov provides the means to indicate the security status of child zones and (if the child supports secure resolution services to enable verification of a chain of trust among parent and child domains, when operating as part of a distributed, hierarchical namespace.
+      By allowing endpoints to use Public Key Infrastructure (PKI) certificates containing unique domain identifiers that map with top-level registered domain, cloud.gov provides the means to indicate the security status of child zones and (if the child supports secure resolution services) to enable verification of a chain of trust among parent and child domains, when operating as part of a distributed, hierarchical namespace.
   standard_key: NIST-800-53
 - control_key: SC-21
   covered_by: []
@@ -367,7 +368,7 @@ satisfies:
   implementation_status: complete
   narrative:
   - text: |
-      cloud.gov protects the confidentiality and integrity of all information by using at rest encryption.
+      cloud.gov protects the confidentiality and integrity of all information by using at-rest encryption.
   parameters:
   - key: a
     text: |
@@ -388,7 +389,7 @@ satisfies:
   implementation_status: complete
   narrative:
   - text: |
-      cloud.gov implements cryptographic mechanisms to prevent unauthorized disclosure and modification of all blobs created by Bosh and Cloud Foundry by implementing at-rest encryption and by checking file signatures.
+      cloud.gov implements cryptographic mechanisms to prevent unauthorized disclosure and modification of all blobs created by BOSH and Cloud Foundry by implementing at-rest encryption and by checking file signatures.
   parameters:
   - key: a
     text: |
@@ -409,7 +410,7 @@ satisfies:
   implementation_status: complete
   narrative:
   - text: |
-      cloud.gov maintains a separate execution domain for each executing process by running within its own self contained environment, a Warden/Garden container that isolates processes, memory, and the file system.
+      cloud.gov maintains a separate execution domain for each executing process by running within its own self-contained environment, a Warden/Garden container that isolates processes, memory, and the file system.
   standard_key: NIST-800-53
 system: 18F
 verifications:


### PR DESCRIPTION
These descriptions had a few grammar and spelling inconsistencies/errors that made the technical information harder to understand, so I tried fixing most of them. This includes guessing that "intera" (https://github.com/18F/cg-compliance/pull/91#discussion_r67282330) meant "internal".