### PR TITLE
fixit! Add protocol to example url.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We're working on a way to [diff the YAML sources with the content of a Word .doc
     - ./your_app_component
   dependencies:
     systems:
-      - url: github.com/18F/cg-compliance
+      - url: https://github.com/18F/cg-compliance
         revision: master
   ```
 


### PR DESCRIPTION
- otherwise `compliance-masonry get` returns an error

Resolves #183 

Tested:
- followed the "Starting ATO Documentation for cloud.gov applications" instructions and noted `compliance-masonry get` error before making change and no error after making change.