### PR TITLE
Add note for compliance.cloud.gov about draft status

### DIFF
--- a/markdowns/README.md
+++ b/markdowns/README.md
@@ -1,6 +1,6 @@
 # FedRAMP Moderate System Security Plan
 
-Note as of November 2016: compliance.cloud.gov is a proof of concept with [old draft content about cloud.gov](https://github.com/18F/cg-compliance#whats-in-this-repository). We're not currently working on updating this site, but we're still working on our SSP separately and plan to update this in the future with our improved SSP.
+Note as of November 2016: compliance.cloud.gov is a proof of concept with [old draft content about cloud.gov](https://github.com/18F/cg-compliance#whats-in-this-repository). We haven't recently updated this site, but we're still working on our SSP separately, and we plan to update this in the future with our improved SSP.
 
 ### 18F - cloud.gov  
 

--- a/markdowns/README.md
+++ b/markdowns/README.md
@@ -1,6 +1,6 @@
 # FedRAMP Moderate System Security Plan
 
-Note: compliance.cloud.gov is a proof of concept with [old draft content about cloud.gov](https://github.com/18F/cg-compliance#whats-in-this-repository). We're not currently working on this proof of concept (November 2016), but we do plan to get back to it when we can.
+Note as of November 2016: compliance.cloud.gov is a proof of concept with [old draft content about cloud.gov](https://github.com/18F/cg-compliance#whats-in-this-repository). We're not currently working on updating this site, but we're still working on our SSP separately and plan to update this in the future with our improved SSP.
 
 ### 18F - cloud.gov  
 

--- a/markdowns/README.md
+++ b/markdowns/README.md
@@ -1,4 +1,7 @@
 # FedRAMP Moderate System Security Plan
+
+Note: compliance.cloud.gov is a proof of concept with [old draft content about cloud.gov](https://github.com/18F/cg-compliance#whats-in-this-repository). We're not currently working on this proof of concept (November 2016), but we do plan to get back to it when we can.
+
 ### 18F - cloud.gov  
 
 * [About the SSP](system_documentation/about-the-ssp.md)


### PR DESCRIPTION
Linking to https://github.com/18F/cg-compliance#whats-in-this-repository from the https://compliance.cloud.gov/ homepage so that random visitors hopefully aren't too confused.

cc @afeld @mogul 